### PR TITLE
Fix a bug where current edit buffer in not cleared at start of download edit buffer with edit buffer capability

### DIFF
--- a/Librarian.cpp
+++ b/Librarian.cpp
@@ -835,28 +835,28 @@ namespace midikraft {
 	void Librarian::handleNextProgramBuffer(std::shared_ptr<SafeMidiOutput> midiOutput, std::shared_ptr<Synth> synth, ProgressHandler* progressHandler, const juce::MidiMessage& editBuffer, MidiBankNumber bankNo) {
 		auto programDumpCapability = midikraft::Capability::hasCapability<ProgramDumpCabability>(synth);
 		// This message might be a part of a multi-message program dump?
-		if (programDumpCapability->isMessagePartOfProgramDump(editBuffer)) {
+		if (programDumpCapability && programDumpCapability->isMessagePartOfProgramDump(editBuffer)) {
 			currentProgramDump_.push_back(editBuffer);
-		}
-		if (programDumpCapability && programDumpCapability->isSingleProgramDump(currentProgramDump_)) {
-			// Ok, that worked, save it and continue!
-			std::copy(currentProgramDump_.begin(), currentProgramDump_.end(), std::back_inserter(currentDownload_));
+			if (programDumpCapability->isSingleProgramDump(currentProgramDump_)) {
+				// Ok, that worked, save it and continue!
+				std::copy(currentProgramDump_.begin(), currentProgramDump_.end(), std::back_inserter(currentDownload_));
 
-			// Finished?
-			if (downloadNumber_ >= endDownloadNumber_-1) {
-				clearHandlers();
-				auto patches = synth->loadSysex(currentDownload_);
-				onFinished_(tagPatchesWithImportFromSynth(synth, patches, bankNo));
-				if (progressHandler) progressHandler->onSuccess();
-			}
-			else if (progressHandler->shouldAbort()) {
-				clearHandlers();
-				if (progressHandler) progressHandler->onCancel();
-			}
-			else {
-				downloadNumber_++;
-				startDownloadNextPatch(midiOutput, synth);
-				if (progressHandler) progressHandler->setProgressPercentage((downloadNumber_ - startDownloadNumber_) / (double)(endDownloadNumber_ - startDownloadNumber_));
+				// Finished?
+				if (downloadNumber_ >= endDownloadNumber_-1) {
+					clearHandlers();
+					auto patches = synth->loadSysex(currentDownload_);
+					onFinished_(tagPatchesWithImportFromSynth(synth, patches, bankNo));
+					if (progressHandler) progressHandler->onSuccess();
+				}
+				else if (progressHandler->shouldAbort()) {
+					clearHandlers();
+					if (progressHandler) progressHandler->onCancel();
+				}
+				else {
+					downloadNumber_++;
+					startDownloadNextPatch(midiOutput, synth);
+					if (progressHandler) progressHandler->setProgressPercentage((downloadNumber_ - startDownloadNumber_) / (double)(endDownloadNumber_ - startDownloadNumber_));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When asking for a download of the current edit buffer, there is a special code to handle the request of a single edit buffer which is not including a clear of `currentEditBuffer_`.
As a result, successive calls to edit buffer download accumulate edit buffers, resulting in invalid edit buffer dumps (depending on how we check for validity, but splitting SysEx messages and checking for the number of messages against a constant value will fail).

A quick fix would be to add a `currentEditBuffer_.clear()` in `downloadEditBuffer` special case code.

Another fix is to reuse `startDownloadNextEditBuffer` (which already contains all the correct logic) but alter it so that it does not include an additional MIDI location message for our special case.

An optional `bool` parameter (defaults to true) can be added to enable MIDI location in this function.
Or another solution is to rely on `downloadNumber_` value, by now considering that negative values disable MIDI location.

In this commit, I choose to use `startDownloadNextEditBuffer` in the special edit buffer download code (so no more special code that would miss some logic), using the negative `downloadNumber_` trick.

I added another commit to optimize the conditionals in `handleNextProgramBuffer` so that we test if `isSingleProgramDump` only if we succeeded in `isMessagePartOfProgramDump` (just like what is already done for the edit buffer where `isEditBufferDump` is tested only if we succeeded in `isMessagePartOfEditBuffer`).